### PR TITLE
Recognize the runtime used by Visual Studio 2015

### DIFF
--- a/src/pe-parser.lua
+++ b/src/pe-parser.lua
@@ -532,6 +532,9 @@ function M.msvcrt(infile)
 	  if not result then
 	    result = dll:match('(MSVCRTD?)%.DLL')
 	  end
+	  if not result then
+	    result = dll:match('(VCRUNTIME%d*D?)%.DLL')
+	  end
     -- success, found it return name + binary where it was found
     if result then return result, infile end
   end


### PR DESCRIPTION
The name of the CRT has changed. It is VCRUNTIME140.dll

Refs #4 