### PR TITLE
Fix typo in pe-parser.lua

### DIFF
--- a/src/pe-parser.lua
+++ b/src/pe-parser.lua
@@ -416,7 +416,7 @@ M.parse = function(target)
           name = "Characteristics"},
       }, f)
   end
-  -- we now have section data, so add RVA convertion method
+  -- we now have section data, so add RVA conversion method
   out.get_fileoffset = M.get_fileoffset
 
   -- get the import table


### PR DESCRIPTION
Upstreamed from: https://github.com/luarocks/luarocks/commit/7a28056921ea81a4c93d3249495866605a913d5c#diff-6ac34a95efbae5660fb9f91400000cb9cf505dfffc67c6443981575b527510e3